### PR TITLE
procd: detect lxc container and behave accordingly

### DIFF
--- a/initd/early.c
+++ b/initd/early.c
@@ -56,14 +56,17 @@ early_mounts(void)
 {
 	unsigned int oldumask = umask(0);
 
-	mount("proc", "/proc", "proc", MS_NOATIME | MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
-	mount("sysfs", "/sys", "sysfs", MS_NOATIME | MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
-	mount("cgroup", "/sys/fs/cgroup", "cgroup",  MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
-	mount("tmpfs", "/dev", "tmpfs", MS_NOATIME | MS_NOSUID, "mode=0755,size=512K");
-	ignore(symlink("/tmp/shm", "/dev/shm"));
-	mkdir("/dev/pts", 0755);
-	mount("devpts", "/dev/pts", "devpts", MS_NOATIME | MS_NOEXEC | MS_NOSUID, "mode=600");
-	early_dev();
+	if (priviledged) {
+		mount("proc", "/proc", "proc", MS_NOATIME | MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
+		mount("sysfs", "/sys", "sysfs", MS_NOATIME | MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
+		mount("cgroup", "/sys/fs/cgroup", "cgroup",  MS_NODEV | MS_NOEXEC | MS_NOSUID, 0);
+		mount("tmpfs", "/dev", "tmpfs", MS_NOATIME | MS_NOSUID, "mode=0755,size=512K");
+		ignore(symlink("/tmp/shm", "/dev/shm"));
+		mkdir("/dev/pts", 0755);
+		mount("devpts", "/dev/pts", "devpts", MS_NOATIME | MS_NOEXEC | MS_NOSUID, "mode=600");
+
+		early_dev();
+	}
 
 	early_console("/dev/console");
 	if (mount_zram_on_tmp()) {

--- a/initd/zram.c
+++ b/initd/zram.c
@@ -116,10 +116,12 @@ mount_zram_on_tmp(void)
 		waitpid(pid, NULL, 0);
 	}
 
-	ret = mount("/dev/zram0", "/tmp", "ext4", MS_NOSUID | MS_NODEV | MS_NOATIME, "errors=continue,noquota");
-	if (ret < 0) {
-		ERROR("Can't mount /dev/zram0 on /tmp: %m\n");
-		return errno;
+	if (priviledged) {
+		ret = mount("/dev/zram0", "/tmp", "ext4", MS_NOSUID | MS_NODEV | MS_NOATIME, "errors=continue,noquota");
+		if (ret < 0) {
+			ERROR("Can't mount /dev/zram0 on /tmp: %m\n");
+			return errno;
+		}
 	}
 
 	LOG("Using up to %ld kB of RAM as ZRAM storage on /mnt\n", zramsize);

--- a/plug/coldplug.c
+++ b/plug/coldplug.c
@@ -43,13 +43,16 @@ void procd_coldplug(void)
 	char *argv[] = { "udevtrigger", NULL };
 	unsigned int oldumask = umask(0);
 
-	umount2("/dev/pts", MNT_DETACH);
-	umount2("/dev/", MNT_DETACH);
-	mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755,size=512K");
+	if (priviledged) {
+		umount2("/dev/pts", MNT_DETACH);
+		umount2("/dev/", MNT_DETACH);
+		mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755,size=512K");
+		mkdir("/dev/pts", 0755);
+		mount("devpts", "/dev/pts", "devpts", MS_NOEXEC | MS_NOSUID, 0);
+	}
+
 	ignore(symlink("/tmp/shm", "/dev/shm"));
-	mkdir("/dev/pts", 0755);
 	umask(oldumask);
-	mount("devpts", "/dev/pts", "devpts", MS_NOEXEC | MS_NOSUID, 0);
 	udevtrigger.cb = udevtrigger_complete;
 	udevtrigger.pid = fork();
 	if (!udevtrigger.pid) {

--- a/procd.c
+++ b/procd.c
@@ -26,6 +26,7 @@
 #include "plug/hotplug.h"
 
 unsigned int debug;
+unsigned int priviledged = 1;
 
 static int usage(const char *prog)
 {
@@ -43,12 +44,19 @@ int main(int argc, char **argv)
 {
 	int ch;
 	char *dbglvl = getenv("DBGLVL");
+	char *container = getenv("container");
 	int ulog_channels = ULOG_KMSG;
 
 	if (dbglvl) {
 		debug = atoi(dbglvl);
 		unsetenv("DBGLVL");
 	}
+
+    if (container) {
+        if (strcmp("lxc",container) != 0) {
+            priviledged = 0;
+        }
+    }
 
 	while ((ch = getopt(argc, argv, "d:s:h:S")) != -1) {
 		switch (ch) {


### PR DESCRIPTION
meaning to not mount some specific parts witch cause trouble.

The patch is based on previous work of *containercraft* to combine
OpenWrt with lxc[0]. This patch however adds a detection copied from
*virt-what* to check /proc/1/environment for "container=lxc".

[0]: https://github.com/containercraft/openwrt-lxd/blob/master/patches/procd-openwrt-18.06/001_lxd_no_mounts.patch

Signed-off-by: Paul Spooren <mail@aparcar.org>